### PR TITLE
For migrate to threejs r136, set dataTexture.needsUpdate = true;

### DIFF
--- a/main.js
+++ b/main.js
@@ -432,6 +432,7 @@ export default e => {
       LinearFilter,
       LinearFilter,
     );
+    offsetTexture2.needsUpdate = true;
     material.uniforms.offsetTexture2.value = offsetTexture2;
 
     const quaternionTexture = new DataTexture(
@@ -446,6 +447,7 @@ export default e => {
       LinearFilter,
       LinearFilter,
     );
+    quaternionTexture.needsUpdate = true;
     material.uniforms.quaternionTexture.value = quaternionTexture;
 
     const quaternionTexture2 = new DataTexture(
@@ -460,6 +462,7 @@ export default e => {
       LinearFilter,
       LinearFilter,
     );
+    quaternionTexture2.needsUpdate = true;
     material.uniforms.quaternionTexture2.value = quaternionTexture2;
   }
 


### PR DESCRIPTION
For migrate to threejs r136, set `dataTexture.needsUpdate = true;`.
According to https://github.com/mrdoob/three.js/wiki/Migration-Guide
>If you create an instance of DataTexture, DataTexture2DArray or DataTexture2DArray, you have to set needsUpdate to true as soon as the texture data are ready.